### PR TITLE
 Add parameter access utilities to machete-ssm 

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,3 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- Added org.starchartlabs.machete.ssm.parameter.SecuredParameter for ease of access to encrypted AWS SSM parameter store values
+- Added org.starchartlabs.machete.ssm.parameter.SecuredRsaKeyParameter  for ease of access to encrypted AWS SSM parameter store values which are the contents of an RSA key
+- Added org.starchartlabs.machete.ssm.parameter.StringParameter for each of access to an un-encrypted AWS SSM value

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -1,0 +1,9 @@
+com.amazonaws:aws-java-sdk-ssm=1.11.423
+
+com.google.code.findbugs:jsr305=3.0.1
+
+org.starchartlabs.alloy:alloy-core=0.4.0
+
+org.mockito:mockito-core=2.12.0
+
+org.testng:testng=6.11

--- a/machete-ssm/.gitignore
+++ b/machete-ssm/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /.settings/
 /build/
+/bin/
+/test-output/

--- a/machete-ssm/build.gradle
+++ b/machete-ssm/build.gradle
@@ -1,0 +1,12 @@
+description = 'Utilities for interacting with Amazon SSM'
+
+//Dependency versions managed in $rootDir/dependencies.properties
+dependencies {
+    compileOnly 'com.google.code.findbugs:jsr305'
+    
+    compile 'com.amazonaws:aws-java-sdk-ssm'
+    compile 'org.starchartlabs.alloy:alloy-core'
+    
+    testCompile 'org.mockito:mockito-core'
+    testCompile 'org.testng:testng'
+}

--- a/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/SecuredParameter.java
+++ b/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/SecuredParameter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.machete.ssm.parameter;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.starchartlabs.alloy.core.Preconditions;
+import org.starchartlabs.alloy.core.Strings;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+
+/**
+ * Represents repeatable access to an encrypted parameter stored on Amazon SSM
+ *
+ * <p>
+ * Implements supplier logic to allow repeated reading of potentially changing values
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class SecuredParameter implements Supplier<String> {
+
+    private final AWSSimpleSystemsManagement systemsManagementClient;
+
+    private final String parameterKey;
+
+    /**
+     * @param systemsManagementClient
+     *            Client instance to use when reading from SSM
+     * @param parameterKey
+     *            The name of the parameter to access
+     * @since 0.1.0
+     */
+    private SecuredParameter(AWSSimpleSystemsManagement systemsManagementClient, String parameterKey) {
+        this.systemsManagementClient = Objects.requireNonNull(systemsManagementClient);
+        this.parameterKey = Objects.requireNonNull(parameterKey);
+    }
+
+    @Override
+    public String get() {
+        GetParameterRequest getParameterRequest = new GetParameterRequest();
+        getParameterRequest.withName(parameterKey);
+        getParameterRequest.setWithDecryption(true);
+
+        GetParameterResult result = systemsManagementClient.getParameter(getParameterRequest);
+
+        return result.getParameter().getValue();
+    }
+
+    /**
+     * Creates a new reference to a secured parameter stored on Amazon SSM
+     *
+     * <p>
+     * Uses the default AWS system management client
+     *
+     * @param environmentVariable
+     *            The name of an environment variable where the name of the parameter to access is stored
+     * @return A secured parameter reference for accessing the stored SSM parameter
+     * @since 0.1.0
+     */
+    public static SecuredParameter fromEnv(String environmentVariable) {
+        return fromEnv(AWSSimpleSystemsManagementClientBuilder.defaultClient(), environmentVariable);
+    }
+
+    /**
+     * Creates a new reference to a secured parameter stored on Amazon SSM
+     *
+     * @param systemsManagementClient
+     *            Client instance to use when reading from SSM
+     * @param environmentVariable
+     *            The name of an environment variable where the name of the parameter to access is stored
+     * @return A secured parameter reference for accessing the stored SSM parameter
+     * @since 0.1.0
+     */
+    public static SecuredParameter fromEnv(AWSSimpleSystemsManagement systemsManagementClient,
+            String environmentVariable) {
+        Objects.requireNonNull(systemsManagementClient);
+        Objects.requireNonNull(environmentVariable);
+
+        String parameterKey = System.getenv(environmentVariable);
+
+        Preconditions.checkArgument(parameterKey != null,
+                () -> Strings.format("Environment variable '%s' is not set", environmentVariable));
+
+        return new SecuredParameter(systemsManagementClient, parameterKey);
+    }
+
+}

--- a/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/SecuredRsaKeyParameter.java
+++ b/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/SecuredRsaKeyParameter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.machete.ssm.parameter;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.starchartlabs.alloy.core.Preconditions;
+import org.starchartlabs.alloy.core.Strings;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+
+/**
+ * Represents repeatable access to an encrypted RSA key parameter stored on Amazon SSM
+ *
+ * <p>
+ * It is intended that the stored parameter is the value between the {@code -----BEGIN RSA PRIVATE KEY-----} and
+ * {@code -----END RSA PRIVATE KEY-----}, excluding that header and footer - this utility re-adds those values to the
+ * resulting value. This is due to an inability to store newlines within an SSM parameter, and RSA key libraries
+ * expecting a specific format.
+ *
+ * <p>
+ * Implements supplier logic to allow repeated reading of potentially changing values
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class SecuredRsaKeyParameter implements Supplier<String> {
+
+    private final AWSSimpleSystemsManagement systemsManagementClient;
+
+    private final String parameterKey;
+
+    /**
+     * @param systemsManagementClient
+     *            Client instance to use when reading from SSM
+     * @param parameterKey
+     *            The name of the parameter to access
+     * @since 0.1.0
+     */
+    private SecuredRsaKeyParameter(AWSSimpleSystemsManagement systemsManagementClient, String parameterKey) {
+        this.systemsManagementClient = Objects.requireNonNull(systemsManagementClient);
+        this.parameterKey = Objects.requireNonNull(parameterKey);
+    }
+
+    @Override
+    public String get() {
+        GetParameterRequest getParameterRequest = new GetParameterRequest();
+        getParameterRequest.withName(parameterKey);
+        getParameterRequest.setWithDecryption(true);
+
+        GetParameterResult result = systemsManagementClient.getParameter(getParameterRequest);
+
+        String key = result.getParameter().getValue();
+
+        return Strings.format("-----BEGIN RSA PRIVATE KEY-----\n%s\n-----END RSA PRIVATE KEY-----", key);
+    }
+
+    /**
+     * Creates a new reference to a secured parameter stored on Amazon SSM that represents a RSA key
+     *
+     * <p>
+     * Uses the default AWS system management client
+     *
+     * @param environmentVariable
+     *            The name of an environment variable where the name of the parameter to access is stored
+     * @return A secured parameter reference for accessing the stored SSM parameter
+     * @since 0.1.0
+     */
+    public static SecuredRsaKeyParameter fromEnv(String environmentVariable) {
+        return fromEnv(AWSSimpleSystemsManagementClientBuilder.defaultClient(), environmentVariable);
+    }
+
+    /**
+     * Creates a new reference to a secured parameter stored on Amazon SSM that represents a RSA key
+     *
+     * @param systemsManagementClient
+     *            Client instance to use when reading from SSM
+     * @param environmentVariable
+     *            The name of an environment variable where the name of the parameter to access is stored
+     * @return A secured parameter reference for accessing the stored SSM parameter
+     * @since 0.1.0
+     */
+    public static SecuredRsaKeyParameter fromEnv(AWSSimpleSystemsManagement systemsManagementClient,
+            String environmentVariable) {
+        Objects.requireNonNull(systemsManagementClient);
+        Objects.requireNonNull(environmentVariable);
+
+        String parameterKey = System.getenv(environmentVariable);
+
+        Preconditions.checkArgument(parameterKey != null,
+                () -> Strings.format("Environment variable '%s' is not set", environmentVariable));
+
+        return new SecuredRsaKeyParameter(systemsManagementClient, parameterKey);
+    }
+
+}

--- a/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/StringParameter.java
+++ b/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/StringParameter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.machete.ssm.parameter;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.starchartlabs.alloy.core.Preconditions;
+import org.starchartlabs.alloy.core.Strings;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+
+/**
+ * Represents repeatable access to a string parameter stored on Amazon SSM
+ *
+ * <p>
+ * Implements supplier logic to allow repeated reading of potentially changing values
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class StringParameter implements Supplier<String> {
+
+    private final AWSSimpleSystemsManagement systemsManagementClient;
+
+    private final String parameterKey;
+
+    /**
+     * @param systemsManagementClient
+     *            Client instance to use when reading from SSM
+     * @param parameterKey
+     *            The name of the parameter to access
+     * @since 0.1.0
+     */
+    private StringParameter(AWSSimpleSystemsManagement systemsManagementClient, String parameterKey) {
+        this.systemsManagementClient = Objects.requireNonNull(systemsManagementClient);
+        this.parameterKey = Objects.requireNonNull(parameterKey);
+    }
+
+    @Override
+    public String get() {
+        GetParameterRequest getParameterRequest = new GetParameterRequest();
+        getParameterRequest.withName(parameterKey);
+        getParameterRequest.setWithDecryption(false);
+
+        GetParameterResult result = systemsManagementClient.getParameter(getParameterRequest);
+
+        return result.getParameter().getValue();
+    }
+
+    /**
+     * Creates a new reference to a string parameter stored on Amazon SSM
+     *
+     * <p>
+     * Uses the default AWS system management client
+     *
+     * @param environmentVariable
+     *            The name of an environment variable where the name of the parameter to access is stored
+     * @return A reference for accessing the stored SSM parameter
+     * @since 0.1.0
+     */
+    public static StringParameter fromEnv(String environmentVariable) {
+        return fromEnv(AWSSimpleSystemsManagementClientBuilder.defaultClient(), environmentVariable);
+    }
+
+    /**
+     * Creates a new reference to a string parameter stored on Amazon SSM
+     *
+     * @param systemsManagementClient
+     *            Client instance to use when reading from SSM
+     * @param environmentVariable
+     *            The name of an environment variable where the name of the parameter to access is stored
+     * @return A reference for accessing the stored SSM parameter
+     * @since 0.1.0
+     */
+    public static StringParameter fromEnv(AWSSimpleSystemsManagement systemsManagementClient,
+            String environmentVariable) {
+        Objects.requireNonNull(systemsManagementClient);
+        Objects.requireNonNull(environmentVariable);
+
+        String parameterKey = System.getenv(environmentVariable);
+
+        Preconditions.checkArgument(parameterKey != null,
+                () -> Strings.format("Environment variable '%s' is not set", environmentVariable));
+
+        return new StringParameter(systemsManagementClient, parameterKey);
+    }
+
+}

--- a/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/package-info.java
+++ b/machete-ssm/src/main/java/org/starchartlabs/machete/ssm/parameter/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+/**
+ * Contains representation used to interact with AWS SSM's parameter store functionality
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+package org.starchartlabs.machete.ssm.parameter;

--- a/machete-ssm/src/test/java/org/starchartlabs/machete/test/ssm/parameter/SecuredParameterTest.java
+++ b/machete-ssm/src/test/java/org/starchartlabs/machete/test/ssm/parameter/SecuredParameterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Nov 2, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.machete.test.ssm.parameter;
+
+import java.util.Map.Entry;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.starchartlabs.machete.ssm.parameter.SecuredParameter;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+
+public class SecuredParameterTest {
+
+    @Mock
+    private AWSSimpleSystemsManagement systemManagementClient;
+
+    @BeforeMethod
+    public void prepareMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fromEnvNullSystemManagementClient() throws Exception {
+        SecuredParameter.fromEnv(null, "ENV_VAR");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fromEnvNullEnvironmentVariable() throws Exception {
+        SecuredParameter.fromEnv(systemManagementClient, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void fromEnvEnvironmentVariableNotSet() throws Exception {
+        SecuredParameter.fromEnv(systemManagementClient, "ENV_VAR");
+    }
+
+    @Test
+    public void get() throws Exception {
+        Entry<String, String> existingEnv = System.getenv().entrySet().stream().findFirst()
+                .orElseThrow(() -> new AssertionError("No existing environment to use for testing"));
+
+        GetParameterRequest expectedRequest = new GetParameterRequest();
+        expectedRequest.withName(existingEnv.getValue());
+        expectedRequest.setWithDecryption(true);
+
+        Parameter param = Mockito.mock(Parameter.class);
+        Mockito.when(param.getValue()).thenReturn("value");
+
+        GetParameterResult result = new GetParameterResult();
+        result.setParameter(param);
+
+        try {
+            Mockito.when(systemManagementClient.getParameter(expectedRequest)).thenReturn(result);
+
+            String value = SecuredParameter.fromEnv(systemManagementClient, existingEnv.getKey()).get();
+
+            Assert.assertNotNull(value);
+            Assert.assertEquals(value, "value");
+        } finally {
+            Mockito.verify(systemManagementClient).getParameter(expectedRequest);
+            Mockito.verify(param).getValue();
+        }
+    }
+
+}

--- a/machete-ssm/src/test/java/org/starchartlabs/machete/test/ssm/parameter/SecuredRsaKeyParameterTest.java
+++ b/machete-ssm/src/test/java/org/starchartlabs/machete/test/ssm/parameter/SecuredRsaKeyParameterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Nov 2, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.machete.test.ssm.parameter;
+
+import java.util.Map.Entry;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.starchartlabs.machete.ssm.parameter.SecuredRsaKeyParameter;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+
+public class SecuredRsaKeyParameterTest {
+
+    @Mock
+    private AWSSimpleSystemsManagement systemManagementClient;
+
+    @BeforeMethod
+    public void prepareMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fromEnvNullSystemManagementClient() throws Exception {
+        SecuredRsaKeyParameter.fromEnv(null, "ENV_VAR");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fromEnvNullEnvironmentVariable() throws Exception {
+        SecuredRsaKeyParameter.fromEnv(systemManagementClient, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void fromEnvEnvironmentVariableNotSet() throws Exception {
+        SecuredRsaKeyParameter.fromEnv(systemManagementClient, "ENV_VAR");
+    }
+
+    @Test
+    public void get() throws Exception {
+        Entry<String, String> existingEnv = System.getenv().entrySet().stream().findFirst()
+                .orElseThrow(() -> new AssertionError("No existing environment to use for testing"));
+
+        GetParameterRequest expectedRequest = new GetParameterRequest();
+        expectedRequest.withName(existingEnv.getValue());
+        expectedRequest.setWithDecryption(true);
+
+        Parameter param = Mockito.mock(Parameter.class);
+        Mockito.when(param.getValue()).thenReturn("value");
+
+        GetParameterResult result = new GetParameterResult();
+        result.setParameter(param);
+
+        try {
+            Mockito.when(systemManagementClient.getParameter(expectedRequest)).thenReturn(result);
+
+            String value = SecuredRsaKeyParameter.fromEnv(systemManagementClient, existingEnv.getKey()).get();
+
+            Assert.assertNotNull(value);
+            Assert.assertEquals(value, "-----BEGIN RSA PRIVATE KEY-----\nvalue\n-----END RSA PRIVATE KEY-----");
+        } finally {
+            Mockito.verify(systemManagementClient).getParameter(expectedRequest);
+            Mockito.verify(param).getValue();
+        }
+    }
+
+}

--- a/machete-ssm/src/test/java/org/starchartlabs/machete/test/ssm/parameter/StringParameterTest.java
+++ b/machete-ssm/src/test/java/org/starchartlabs/machete/test/ssm/parameter/StringParameterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Nov 2, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.machete.test.ssm.parameter;
+
+import java.util.Map.Entry;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.starchartlabs.machete.ssm.parameter.StringParameter;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+
+public class StringParameterTest {
+
+    @Mock
+    private AWSSimpleSystemsManagement systemManagementClient;
+
+    @BeforeMethod
+    public void prepareMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fromEnvNullSystemManagementClient() throws Exception {
+        StringParameter.fromEnv(null, "ENV_VAR");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fromEnvNullEnvironmentVariable() throws Exception {
+        StringParameter.fromEnv(systemManagementClient, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void fromEnvEnvironmentVariableNotSet() throws Exception {
+        StringParameter.fromEnv(systemManagementClient, "ENV_VAR");
+    }
+
+    @Test
+    public void get() throws Exception {
+        Entry<String, String> existingEnv = System.getenv().entrySet().stream().findFirst()
+                .orElseThrow(() -> new AssertionError("No existing environment to use for testing"));
+
+        GetParameterRequest expectedRequest = new GetParameterRequest();
+        expectedRequest.withName(existingEnv.getValue());
+        expectedRequest.setWithDecryption(false);
+
+        Parameter param = Mockito.mock(Parameter.class);
+        Mockito.when(param.getValue()).thenReturn("value");
+
+        GetParameterResult result = new GetParameterResult();
+        result.setParameter(param);
+
+        try {
+            Mockito.when(systemManagementClient.getParameter(expectedRequest)).thenReturn(result);
+
+            String value = StringParameter.fromEnv(systemManagementClient, existingEnv.getKey()).get();
+
+            Assert.assertNotNull(value);
+            Assert.assertEquals(value, "value");
+        } finally {
+            Mockito.verify(systemManagementClient).getParameter(expectedRequest);
+            Mockito.verify(param).getValue();
+        }
+    }
+
+}


### PR DESCRIPTION
Add utilities for accessing various formats of values from AWS SSM in streamlined ways