### PR TITLE
Add SNS utilities to machete libraries

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added org.starchartlabs.machete.ssm.parameter.SecuredParameter for ease of access to encrypted AWS SSM parameter store values
 - Added org.starchartlabs.machete.ssm.parameter.SecuredRsaKeyParameter  for ease of access to encrypted AWS SSM parameter store values which are the contents of an RSA key
 - Added org.starchartlabs.machete.ssm.parameter.StringParameter for each of access to an un-encrypted AWS SSM value
+- Added org.starchartlabs.machete.sns.SnsEvents for utilities related to SNS event processing

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ If you discover a security vulnerability, contact the development team by e-mail
 
 ## Projects
 
+### machete-sns
+
+Contains utilities for interacting with [Amazon SNS](https://aws.amazon.com/sns/)
+
 ### machete-ssm
 
 Contains utilities for interacting with [Amazon SSM](https://docs.aws.amazon.com/systems-manager)

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -1,4 +1,5 @@
 com.amazonaws:aws-java-sdk-ssm=1.11.423
+com.amazonaws:aws-lambda-java-events=2.2.2
 
 com.google.code.findbugs:jsr305=3.0.1
 

--- a/machete-sns/.gitignore
+++ b/machete-sns/.gitignore
@@ -1,0 +1,6 @@
+/.classpath
+/.project
+/.settings/
+/bin/
+/test-output/
+/build/

--- a/machete-sns/build.gradle
+++ b/machete-sns/build.gradle
@@ -1,0 +1,12 @@
+description = 'Utilities for interacting with Amazon SNS'
+
+//Dependency versions managed in $rootDir/dependencies.properties
+dependencies {
+    compileOnly 'com.google.code.findbugs:jsr305'
+    
+    compile 'com.amazonaws:aws-lambda-java-events'
+    compile 'org.starchartlabs.alloy:alloy-core'
+    
+    testCompile 'org.mockito:mockito-core'
+    testCompile 'org.testng:testng'
+}

--- a/machete-sns/src/main/java/org/starchartlabs/machete/sns/SnsEvents.java
+++ b/machete-sns/src/main/java/org/starchartlabs/machete/sns/SnsEvents.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.machete.sns;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNS;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNSRecord;
+
+/**
+ * Represents common utility operations related to AWS SNS event payloads
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public final class SnsEvents {
+
+    /**
+     * Prevent instantiation of utility class
+     */
+    private SnsEvents() throws InstantiationException {
+        throw new InstantiationException("Cannot instantiate instance of utility class '" + getClass().getName() + "'");
+    }
+
+    /**
+     * Extracts SNS message payload(s) from a received set of SNS messages
+     *
+     * @param snsEvent
+     *            The SNS payload to read from
+     * @param toEvent
+     *            Function for converting string payload(s) to a meaningful Java representation
+     * @param subject
+     *            Message subject to filter matches to. May be null to prevent any subject-based filtering
+     * @param <T>
+     *            Java representation of event to provide
+     * @return A collection of converted message payload(s)
+     * @since 0.1.0
+     */
+    public static <T> Collection<T> getMessages(SNSEvent snsEvent, Function<String, T> toEvent, @Nullable String subject) {
+        Objects.requireNonNull(snsEvent);
+        Objects.requireNonNull(toEvent);
+
+        return snsEvent.getRecords().stream()
+                .map(SNSRecord::getSNS)
+                .filter(sns -> subject == null || Objects.equals(sns.getSubject(), subject))
+                .map(SNS::getMessage)
+                .map(toEvent)
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/machete-sns/src/main/java/org/starchartlabs/machete/sns/package-info.java
+++ b/machete-sns/src/main/java/org/starchartlabs/machete/sns/package-info.java
@@ -5,10 +5,10 @@
  * of the MIT license. See the LICENSE file for details.
  */
 /**
- * Contains representation used to interact with AWS SSM's parameter store functionality
+ * Contains representation used to interact with AWS SNS
  *
  * @author romeara
  * @since 0.1.0
  */
 @javax.annotation.ParametersAreNonnullByDefault
-package org.starchartlabs.machete.ssm.parameter;
+package org.starchartlabs.machete.sns;

--- a/machete-sns/src/test/java/org/starchartlabs/machete/test/sns/SnsEventsTest.java
+++ b/machete-sns/src/test/java/org/starchartlabs/machete/test/sns/SnsEventsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.machete.test.sns;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Function;
+
+import org.mockito.Mockito;
+import org.starchartlabs.machete.sns.SnsEvents;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNS;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNSRecord;
+
+public class SnsEventsTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void toMessagesNullSnsEvent() throws Exception {
+        SnsEvents.getMessages(null, Function.identity(), "subject");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void toMessagesNulltoEvent() throws Exception {
+        SNSEvent snsEvent = Mockito.mock(SNSEvent.class);
+
+        SnsEvents.getMessages(snsEvent, null, "subject");
+    }
+
+    @Test
+    public void toMessagesNullSubject() throws Exception {
+        SNSRecord record1 = createRecordMock("subject1", "message1");
+        SNSRecord record2 = createRecordMock("subject2", "message2");
+
+        SNSEvent snsEvent = Mockito.mock(SNSEvent.class);
+        Mockito.when(snsEvent.getRecords()).thenReturn(Arrays.asList(record1, record2));
+
+        Collection<String> result = SnsEvents.getMessages(snsEvent, Function.identity(), null);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 2);
+        Assert.assertTrue(result.contains(record1.getSNS().getMessage()));
+        Assert.assertTrue(result.contains(record2.getSNS().getMessage()));
+    }
+
+    @Test
+    public void toMessages() throws Exception {
+        SNSRecord record1 = createRecordMock("subject1", "message1");
+        SNSRecord record2 = createRecordMock("subject2", "message2");
+
+        SNSEvent snsEvent = Mockito.mock(SNSEvent.class);
+        Mockito.when(snsEvent.getRecords()).thenReturn(Arrays.asList(record1, record2));
+
+        Collection<String> result = SnsEvents.getMessages(snsEvent, Function.identity(), record1.getSNS().getSubject());
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertTrue(result.contains(record1.getSNS().getMessage()));
+    }
+
+    private SNSRecord createRecordMock(String subject, String message) {
+        SNS sns = Mockito.mock(SNS.class);
+        Mockito.when(sns.getSubject()).thenReturn(subject);
+        Mockito.when(sns.getMessage()).thenReturn(message);
+
+        SNSRecord record = Mockito.mock(SNSRecord.class);
+        Mockito.when(record.getSNS()).thenReturn(sns);
+
+        return record;
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
+include 'machete-sns'
 include 'machete-ssm'


### PR DESCRIPTION
Add utilities for handling SNS events, as the first entry in a general set of SNS-related library functions